### PR TITLE
Fix animated icon initialization order for GNOME Shell

### DIFF
--- a/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
+++ b/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
@@ -163,14 +163,15 @@ public class DBusAnimatedIcon : IDisposable
             _connection.AddMethodHandler(_pathHandler);
 
             _sysTrayServiceName = $"org.kde.StatusNotifierItem-{pid}-{tid}";
+
+            // Set first frame BEFORE registration so GNOME Shell reads valid pixmap
+            _currentFrameIndex = 0;
+            SetCurrentFrame();
+
             await _dBus!.RequestNameAsync(_sysTrayServiceName, 0);
             await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
 
             _isVisible = true;
-
-            // Set first frame and start animation
-            _currentFrameIndex = 0;
-            SetCurrentFrame();
             _animationTimer = new Timer(AnimationCallback, null, _intervalMs, _intervalMs);
 
             _logger.LogDebug("Animated icon shown as {ServiceName}", _sysTrayServiceName);


### PR DESCRIPTION
## Summary
- Set first frame pixmap BEFORE registering with StatusNotifierWatcher
- GNOME Shell reads `IconPixmap` immediately after registration, so the pixmap must be valid beforehand
- Prevents fallback "three dots" icon from showing during transcription

## Root Cause
In `ShowAsync()`, the icon was registered with StatusNotifierWatcher before `SetCurrentFrame()` was called. At registration time, `IconPixmap` was still `Array.Empty<(int, int, byte[])>()` from the constructor, causing GNOME Shell to display a fallback icon.

## Changes
**Before:**
```csharp
await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
_isVisible = true;
_currentFrameIndex = 0;
SetCurrentFrame();  // TOO LATE - GNOME already read empty pixmap
```

**After:**
```csharp
_currentFrameIndex = 0;
SetCurrentFrame();  // Set pixmap FIRST
await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
_isVisible = true;
```

## Test Plan
- [ ] Build the application
- [ ] Start transcription and verify animated icon shows document frame animation
- [ ] Verify animation cycles through all frames properly

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)