### PR TITLE
Change animated icon diagnostic logs to Information level

### DIFF
--- a/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
+++ b/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
@@ -160,7 +160,7 @@ public class DBusAnimatedIcon : IDisposable
     {
         if (_isDisposed || !_serviceConnected || _isVisible || _statusNotifierWatcher is null)
         {
-            _logger.LogDebug("ShowAsync skipped: disposed={Disposed}, connected={Connected}, visible={Visible}, watcher={HasWatcher}",
+            _logger.LogInformation("ShowAsync skipped: disposed={Disposed}, connected={Connected}, visible={Visible}, watcher={HasWatcher}",
                 _isDisposed, _serviceConnected, _isVisible, _statusNotifierWatcher is not null);
             return;
         }
@@ -189,7 +189,7 @@ public class DBusAnimatedIcon : IDisposable
             _isVisible = true;
             _animationTimer = new Timer(AnimationCallback, null, _intervalMs, _intervalMs);
 
-            _logger.LogDebug("Animated icon shown as {ServiceName}", _sysTrayServiceName);
+            _logger.LogInformation("Animated icon shown as {ServiceName}", _sysTrayServiceName);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
Change key diagnostic logs from `LogDebug` to `LogInformation` so they're visible in console output.

## Changes
- `ShowAsync skipped` message → `LogInformation`
- `Animated icon shown` message → `LogInformation`

This will help diagnose why the animated icon shows "three dots" instead of the animation.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)