### PR TITLE
Fix animated icon: use standard /StatusNotifierItem path

### DIFF
--- a/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
+++ b/src/Olbrasoft.SpeechToText.App/DBusAnimatedIcon.cs
@@ -63,8 +63,9 @@ public class DBusAnimatedIcon : IDisposable
 
             _dBus = new OrgFreedesktopDBusProxy(_connection, "org.freedesktop.DBus", "/org/freedesktop/DBus");
 
-            // Use different path to avoid conflicts with main icon
-            _pathHandler = new PathHandler("/AnimatedIcon");
+            // Use standard StatusNotifierItem path - each icon has its own D-Bus connection
+            // so there's no conflict with the main icon
+            _pathHandler = new PathHandler("/StatusNotifierItem");
             _sniHandler = new AnimatedIconHandler(_connection, _logger);
 
             _pathHandler.Add(_sniHandler);


### PR DESCRIPTION
## Summary
Fix the animated icon by using the standard `/StatusNotifierItem` object path instead of custom `/AnimatedIcon`.

## Root Cause
Comparing working `DBusTrayIcon` with broken `DBusAnimatedIcon`:

| Component | DBusTrayIcon (works) | DBusAnimatedIcon (broken) |
|-----------|---------------------|--------------------------|
| PathHandler | `/StatusNotifierItem` | `/AnimatedIcon` ❌ |

The StatusNotifierItem specification requires icons to be served at `/StatusNotifierItem` path. GNOME Shell looks for properties at this standard path, but the animated icon was using a custom `/AnimatedIcon` path - so GNOME couldn't find the icon data and displayed a fallback.

## Why This Works
Each icon creates its own D-Bus connection with a unique service name:
- Main icon: `org.kde.StatusNotifierItem-{pid}-N` 
- Animated icon: `org.kde.StatusNotifierItem-{pid}-1000+`

Since they're separate connections, both can use `/StatusNotifierItem` without conflict.

## Test Plan
- [ ] Build and deploy
- [ ] Start transcription
- [ ] Verify animated document icon appears (not three dots)

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)