### PR TITLE
Refactor: Extract key simulation from EvdevKeyboardMonitor (ISP)

### DIFF
--- a/src/Olbrasoft.SpeechToText/IButtonAction.cs
+++ b/src/Olbrasoft.SpeechToText/IButtonAction.cs
@@ -23,12 +23,14 @@ public interface IButtonAction
 /// </summary>
 public class KeyPressAction : IButtonAction
 {
+    private readonly IKeySimulator _keySimulator;
     private readonly IKeyboardMonitor _keyboardMonitor;
     private readonly KeyCode _keyCode;
     private readonly bool _raiseReleaseEvent;
 
-    public KeyPressAction(IKeyboardMonitor keyboardMonitor, KeyCode keyCode, string name, bool raiseReleaseEvent = true)
+    public KeyPressAction(IKeySimulator keySimulator, IKeyboardMonitor keyboardMonitor, KeyCode keyCode, string name, bool raiseReleaseEvent = true)
     {
+        _keySimulator = keySimulator ?? throw new ArgumentNullException(nameof(keySimulator));
         _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
         _keyCode = keyCode;
         Name = name;
@@ -39,7 +41,7 @@ public class KeyPressAction : IButtonAction
 
     public async Task ExecuteAsync()
     {
-        await _keyboardMonitor.SimulateKeyPressAsync(_keyCode);
+        await _keySimulator.SimulateKeyPressAsync(_keyCode);
         if (_raiseReleaseEvent)
         {
             await Task.Delay(MultiClickDetector.KeySimulationDelayMs);
@@ -53,13 +55,13 @@ public class KeyPressAction : IButtonAction
 /// </summary>
 public class KeyComboAction : IButtonAction
 {
-    private readonly IKeyboardMonitor _keyboardMonitor;
+    private readonly IKeySimulator _keySimulator;
     private readonly KeyCode _modifier;
     private readonly KeyCode _key;
 
-    public KeyComboAction(IKeyboardMonitor keyboardMonitor, KeyCode modifier, KeyCode key, string name)
+    public KeyComboAction(IKeySimulator keySimulator, KeyCode modifier, KeyCode key, string name)
     {
-        _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
+        _keySimulator = keySimulator ?? throw new ArgumentNullException(nameof(keySimulator));
         _modifier = modifier;
         _key = key;
         Name = name;
@@ -69,7 +71,7 @@ public class KeyComboAction : IButtonAction
 
     public async Task ExecuteAsync()
     {
-        await _keyboardMonitor.SimulateKeyComboAsync(_modifier, _key);
+        await _keySimulator.SimulateKeyComboAsync(_modifier, _key);
     }
 }
 
@@ -78,19 +80,19 @@ public class KeyComboAction : IButtonAction
 /// </summary>
 public class KeyComboWithTwoModifiersAction : IButtonAction
 {
-    private readonly IKeyboardMonitor _keyboardMonitor;
+    private readonly IKeySimulator _keySimulator;
     private readonly KeyCode _modifier1;
     private readonly KeyCode _modifier2;
     private readonly KeyCode _key;
 
     public KeyComboWithTwoModifiersAction(
-        IKeyboardMonitor keyboardMonitor,
+        IKeySimulator keySimulator,
         KeyCode modifier1,
         KeyCode modifier2,
         KeyCode key,
         string name)
     {
-        _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
+        _keySimulator = keySimulator ?? throw new ArgumentNullException(nameof(keySimulator));
         _modifier1 = modifier1;
         _modifier2 = modifier2;
         _key = key;
@@ -101,7 +103,7 @@ public class KeyComboWithTwoModifiersAction : IButtonAction
 
     public async Task ExecuteAsync()
     {
-        await _keyboardMonitor.SimulateKeyComboAsync(_modifier1, _modifier2, _key);
+        await _keySimulator.SimulateKeyComboAsync(_modifier1, _modifier2, _key);
     }
 }
 

--- a/src/Olbrasoft.SpeechToText/IKeySimulator.cs
+++ b/src/Olbrasoft.SpeechToText/IKeySimulator.cs
@@ -1,0 +1,28 @@
+namespace Olbrasoft.SpeechToText;
+
+/// <summary>
+/// Interface for simulating keyboard input (ISP: separated from keyboard monitoring).
+/// </summary>
+public interface IKeySimulator
+{
+    /// <summary>
+    /// Simulates a key press and release.
+    /// </summary>
+    /// <param name="key">The key to simulate.</param>
+    Task SimulateKeyPressAsync(KeyCode key);
+
+    /// <summary>
+    /// Simulates a key combination (modifier + key).
+    /// </summary>
+    /// <param name="modifier">The modifier key (e.g., LeftControl).</param>
+    /// <param name="key">The key to press with the modifier.</param>
+    Task SimulateKeyComboAsync(KeyCode modifier, KeyCode key);
+
+    /// <summary>
+    /// Simulates a key combination with two modifiers (modifier1 + modifier2 + key).
+    /// </summary>
+    /// <param name="modifier1">The first modifier key.</param>
+    /// <param name="modifier2">The second modifier key.</param>
+    /// <param name="key">The key to press with the modifiers.</param>
+    Task SimulateKeyComboAsync(KeyCode modifier1, KeyCode modifier2, KeyCode key);
+}

--- a/src/Olbrasoft.SpeechToText/IKeyboardMonitor.cs
+++ b/src/Olbrasoft.SpeechToText/IKeyboardMonitor.cs
@@ -1,7 +1,8 @@
 namespace Olbrasoft.SpeechToText;
 
 /// <summary>
-/// Interface for monitoring keyboard events (cross-platform abstraction).
+/// Interface for monitoring keyboard events (ISP: read-only operations).
+/// Key simulation is handled by IKeySimulator.
 /// </summary>
 public interface IKeyboardMonitor : IDisposable
 {
@@ -44,34 +45,10 @@ public interface IKeyboardMonitor : IDisposable
     bool IsScrollLockOn();
 
     /// <summary>
-    /// Simulates a key press and release using uinput.
-    /// Used to toggle ScrollLock from software (e.g., tray menu click).
-    /// </summary>
-    /// <param name="key">The key to simulate.</param>
-    Task SimulateKeyPressAsync(KeyCode key);
-
-    /// <summary>
     /// Programmatically raises a KeyReleased event without actually pressing the key.
     /// Used by BluetoothMouseMonitor to trigger DictationWorker without physical key press.
     /// This does NOT change LED state - only raises the event for subscribers.
     /// </summary>
     /// <param name="key">The key to raise event for.</param>
     void RaiseKeyReleasedEvent(KeyCode key);
-
-    /// <summary>
-    /// Simulates a key combination (modifier + key) using uinput.
-    /// Used for keyboard shortcuts like Ctrl+C, Ctrl+V, etc.
-    /// </summary>
-    /// <param name="modifier">The modifier key (e.g., LeftControl, LeftShift).</param>
-    /// <param name="key">The key to press with the modifier.</param>
-    Task SimulateKeyComboAsync(KeyCode modifier, KeyCode key);
-
-    /// <summary>
-    /// Simulates a key combination with two modifiers (modifier1 + modifier2 + key) using uinput.
-    /// Used for keyboard shortcuts like Ctrl+Shift+V.
-    /// </summary>
-    /// <param name="modifier1">The first modifier key (e.g., LeftControl).</param>
-    /// <param name="modifier2">The second modifier key (e.g., LeftShift).</param>
-    /// <param name="key">The key to press with the modifiers.</param>
-    Task SimulateKeyComboAsync(KeyCode modifier1, KeyCode modifier2, KeyCode key);
 }

--- a/src/Olbrasoft.SpeechToText/UinputKeySimulator.cs
+++ b/src/Olbrasoft.SpeechToText/UinputKeySimulator.cs
@@ -1,0 +1,317 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.SpeechToText;
+
+/// <summary>
+/// Linux uinput-based key simulator using Python for low-level device control.
+/// </summary>
+public class UinputKeySimulator : IKeySimulator
+{
+    private readonly ILogger<UinputKeySimulator> _logger;
+    private const string UinputPath = "/dev/uinput";
+
+    public UinputKeySimulator(ILogger<UinputKeySimulator> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public async Task SimulateKeyPressAsync(KeyCode key)
+    {
+        try
+        {
+            _logger.LogInformation("Simulating key press: {Key}", key);
+
+            if (!File.Exists(UinputPath))
+            {
+                _logger.LogError("uinput device not found at {Path}", UinputPath);
+                return;
+            }
+
+            var keyCode = (int)key;
+            var script = GenerateSingleKeyScript(keyCode);
+
+            await ExecutePythonScriptAsync(script, $"key press: {key}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error simulating key press: {Key}", key);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task SimulateKeyComboAsync(KeyCode modifier, KeyCode key)
+    {
+        try
+        {
+            _logger.LogInformation("Simulating key combo: {Modifier}+{Key}", modifier, key);
+
+            if (!File.Exists(UinputPath))
+            {
+                _logger.LogError("uinput device not found at {Path}", UinputPath);
+                return;
+            }
+
+            var modifierCode = (int)modifier;
+            var keyCode = (int)key;
+            var script = GenerateTwoKeyComboScript(modifierCode, keyCode);
+
+            await ExecutePythonScriptAsync(script, $"key combo: {modifier}+{key}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error simulating key combo: {Modifier}+{Key}", modifier, key);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task SimulateKeyComboAsync(KeyCode modifier1, KeyCode modifier2, KeyCode key)
+    {
+        try
+        {
+            _logger.LogInformation("Simulating key combo: {Modifier1}+{Modifier2}+{Key}", modifier1, modifier2, key);
+
+            if (!File.Exists(UinputPath))
+            {
+                _logger.LogError("uinput device not found at {Path}", UinputPath);
+                return;
+            }
+
+            var mod1Code = (int)modifier1;
+            var mod2Code = (int)modifier2;
+            var keyCode = (int)key;
+            var script = GenerateThreeKeyComboScript(mod1Code, mod2Code, keyCode);
+
+            await ExecutePythonScriptAsync(script, $"key combo: {modifier1}+{modifier2}+{key}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error simulating key combo: {Modifier1}+{Modifier2}+{Key}", modifier1, modifier2, key);
+        }
+    }
+
+    private async Task ExecutePythonScriptAsync(string script, string operationDescription)
+    {
+        var processInfo = new ProcessStartInfo
+        {
+            FileName = "python3",
+            Arguments = $"-c \"{script.Replace("\"", "\\\"")}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(processInfo);
+        if (process != null)
+        {
+            await process.WaitForExitAsync();
+            var stderr = await process.StandardError.ReadToEndAsync();
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogError("Failed to simulate {Operation}. Exit code: {ExitCode}, Error: {Error}",
+                    operationDescription, process.ExitCode, stderr);
+            }
+            else
+            {
+                _logger.LogInformation("Successfully simulated {Operation}", operationDescription);
+            }
+        }
+    }
+
+    private static string GenerateSingleKeyScript(int keyCode) => $@"
+import os
+import time
+import struct
+import fcntl
+
+# uinput constants
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+EV_KEY = 0x01
+EV_SYN = 0x00
+SYN_REPORT = 0x00
+
+# Open uinput
+fd = os.open('/dev/uinput', os.O_WRONLY | os.O_NONBLOCK)
+
+# Enable EV_KEY
+fcntl.ioctl(fd, UI_SET_EVBIT, EV_KEY)
+
+# Enable the specific key
+fcntl.ioctl(fd, UI_SET_KEYBIT, {keyCode})
+
+# uinput_user_dev structure (legacy)
+name = b'speech-to-text-kbd'
+name = name + b'\x00' * (80 - len(name))
+user_dev = name + struct.pack('<HHHHI', 0x03, 0x1234, 0x5678, 0x0001, 0)
+user_dev = user_dev + b'\x00' * (4 * 64 * 4)
+
+os.write(fd, user_dev)
+fcntl.ioctl(fd, UI_DEV_CREATE)
+
+time.sleep(0.1)
+
+def send_event(fd, ev_type, code, value):
+    event = struct.pack('<QQHHi', 0, 0, ev_type, code, value)
+    os.write(fd, event)
+
+send_event(fd, EV_KEY, {keyCode}, 1)  # Press
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+
+time.sleep(0.05)
+
+send_event(fd, EV_KEY, {keyCode}, 0)  # Release
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+
+time.sleep(0.1)
+
+fcntl.ioctl(fd, UI_DEV_DESTROY)
+os.close(fd)
+";
+
+    private static string GenerateTwoKeyComboScript(int modifierCode, int keyCode) => $@"
+import os
+import time
+import struct
+import fcntl
+
+# uinput constants
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+EV_KEY = 0x01
+EV_SYN = 0x00
+SYN_REPORT = 0x00
+
+# Open uinput
+fd = os.open('/dev/uinput', os.O_WRONLY | os.O_NONBLOCK)
+
+# Enable EV_KEY
+fcntl.ioctl(fd, UI_SET_EVBIT, EV_KEY)
+
+# Enable both keys
+fcntl.ioctl(fd, UI_SET_KEYBIT, {modifierCode})
+fcntl.ioctl(fd, UI_SET_KEYBIT, {keyCode})
+
+# Create uinput device
+name = b'speech-to-text-kbd'
+name = name + b'\x00' * (80 - len(name))
+user_dev = name + struct.pack('<HHHHI', 0x03, 0x1234, 0x5678, 0x0001, 0)
+user_dev = user_dev + b'\x00' * (4 * 64 * 4)
+
+os.write(fd, user_dev)
+fcntl.ioctl(fd, UI_DEV_CREATE)
+
+time.sleep(0.1)
+
+def send_event(fd, ev_type, code, value):
+    event = struct.pack('<QQHHi', 0, 0, ev_type, code, value)
+    os.write(fd, event)
+
+# Press modifier
+send_event(fd, EV_KEY, {modifierCode}, 1)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Press key
+send_event(fd, EV_KEY, {keyCode}, 1)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.05)
+
+# Release key
+send_event(fd, EV_KEY, {keyCode}, 0)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Release modifier
+send_event(fd, EV_KEY, {modifierCode}, 0)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+
+time.sleep(0.1)
+
+fcntl.ioctl(fd, UI_DEV_DESTROY)
+os.close(fd)
+";
+
+    private static string GenerateThreeKeyComboScript(int mod1Code, int mod2Code, int keyCode) => $@"
+import os
+import time
+import struct
+import fcntl
+
+# uinput constants
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+EV_KEY = 0x01
+EV_SYN = 0x00
+SYN_REPORT = 0x00
+
+# Open uinput
+fd = os.open('/dev/uinput', os.O_WRONLY | os.O_NONBLOCK)
+
+# Enable EV_KEY
+fcntl.ioctl(fd, UI_SET_EVBIT, EV_KEY)
+
+# Enable all keys
+fcntl.ioctl(fd, UI_SET_KEYBIT, {mod1Code})
+fcntl.ioctl(fd, UI_SET_KEYBIT, {mod2Code})
+fcntl.ioctl(fd, UI_SET_KEYBIT, {keyCode})
+
+# Create uinput device
+name = b'speech-to-text-kbd'
+name = name + b'\x00' * (80 - len(name))
+user_dev = name + struct.pack('<HHHHI', 0x03, 0x1234, 0x5678, 0x0001, 0)
+user_dev = user_dev + b'\x00' * (4 * 64 * 4)
+
+os.write(fd, user_dev)
+fcntl.ioctl(fd, UI_DEV_CREATE)
+
+time.sleep(0.1)
+
+def send_event(fd, ev_type, code, value):
+    event = struct.pack('<QQHHi', 0, 0, ev_type, code, value)
+    os.write(fd, event)
+
+# Press modifier1
+send_event(fd, EV_KEY, {mod1Code}, 1)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Press modifier2
+send_event(fd, EV_KEY, {mod2Code}, 1)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Press key
+send_event(fd, EV_KEY, {keyCode}, 1)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.05)
+
+# Release key
+send_event(fd, EV_KEY, {keyCode}, 0)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Release modifier2
+send_event(fd, EV_KEY, {mod2Code}, 0)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+time.sleep(0.02)
+
+# Release modifier1
+send_event(fd, EV_KEY, {mod1Code}, 0)
+send_event(fd, EV_SYN, SYN_REPORT, 0)
+
+time.sleep(0.1)
+
+fcntl.ioctl(fd, UI_DEV_DESTROY)
+os.close(fd)
+";
+}


### PR DESCRIPTION
## Summary
- Created `IKeySimulator` interface for key simulation operations (ISP)
- Created `UinputKeySimulator` class with Python-based uinput simulation
- Removed `SimulateKeyPressAsync`, `SimulateKeyComboAsync` from `IKeyboardMonitor`
- Updated `IButtonAction` classes to use `IKeySimulator`
- Updated `BluetoothMouseMonitor` and `UsbMouseMonitor` constructors
- Registered `IKeySimulator` in Service DI container

## Benefits
- `EvdevKeyboardMonitor` reduced from 757 to 396 lines (-48%)
- Clear separation of concerns (monitoring vs simulation)
- Better testability (can mock `IKeySimulator` independently)
- Follows ISP - clients depend only on interfaces they use

## Test plan
- [ ] Build passes
- [ ] Application starts correctly
- [ ] Key simulation works via mouse buttons
- [ ] Keyboard monitoring still works

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)