### PR TITLE
Implement IAsyncDisposable for async cleanup

### DIFF
--- a/src/Olbrasoft.SpeechToText.App/DictationService.cs
+++ b/src/Olbrasoft.SpeechToText.App/DictationService.cs
@@ -17,8 +17,9 @@ public enum DictationState
 /// <summary>
 /// Orchestrates the dictation workflow: recording, transcription, and text typing.
 /// </summary>
-public class DictationService : IDisposable
+public class DictationService : IDisposable, IAsyncDisposable
 {
+    private bool _disposed;
     private readonly ILogger<DictationService> _logger;
     private readonly IKeyboardMonitor _keyboardMonitor;
     private readonly IAudioRecorder _audioRecorder;
@@ -257,10 +258,35 @@ public class DictationService : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _keyboardMonitor.KeyReleased -= OnKeyReleased;
         _cts?.Cancel();
         _cts?.Dispose();
         _typingSoundPlayer?.Dispose();
         _speechTranscriber.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _keyboardMonitor.KeyReleased -= OnKeyReleased;
+
+        // Async cleanup
+        await StopMonitoringAsync();
+
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _typingSoundPlayer?.Dispose();
+        _speechTranscriber.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Olbrasoft.SpeechToText/AlsaAudioRecorder.cs
+++ b/src/Olbrasoft.SpeechToText/AlsaAudioRecorder.cs
@@ -254,6 +254,8 @@ public class AlsaAudioRecorder : IAudioRecorder
         if (_disposed)
             return;
 
+        _disposed = true;
+
         if (_isRecording)
         {
             StopRecordingAsync().GetAwaiter().GetResult();
@@ -263,7 +265,26 @@ public class AlsaAudioRecorder : IAudioRecorder
         _recordProcess?.Dispose();
         _recordedData.Clear();
 
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
         _disposed = true;
+
+        if (_isRecording)
+        {
+            await StopRecordingAsync();
+        }
+
+        _cts?.Dispose();
+        _recordProcess?.Dispose();
+        _recordedData.Clear();
+
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Olbrasoft.SpeechToText/IAudioRecorder.cs
+++ b/src/Olbrasoft.SpeechToText/IAudioRecorder.cs
@@ -3,7 +3,7 @@ namespace Olbrasoft.SpeechToText;
 /// <summary>
 /// Interface for audio recording from microphone.
 /// </summary>
-public interface IAudioRecorder : IDisposable
+public interface IAudioRecorder : IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// Event raised when audio data chunk is available.

--- a/src/Olbrasoft.SpeechToText/NAudioRecorder.cs
+++ b/src/Olbrasoft.SpeechToText/NAudioRecorder.cs
@@ -170,15 +170,35 @@ public class NAudioRecorder : IAudioRecorder
         if (_disposed)
             return;
 
+        _disposed = true;
+
         if (_isRecording)
         {
-            StopRecordingAsync().Wait();
+            StopRecordingAsync().GetAwaiter().GetResult();
         }
 
         _waveIn?.Dispose();
         _recordedData.Clear();
 
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
         _disposed = true;
+
+        if (_isRecording)
+        {
+            await StopRecordingAsync();
+        }
+
+        _waveIn?.Dispose();
+        _recordedData.Clear();
+
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary

- Added `IAsyncDisposable` to `IAudioRecorder` interface for proper async cleanup
- Implemented `DisposeAsync` in `DictationService` with async `StopMonitoringAsync`
- Implemented `DisposeAsync` in `AlsaAudioRecorder` with async `StopRecordingAsync`
- Implemented `DisposeAsync` in `NAudioRecorder` with async `StopRecordingAsync`
- Standardized disposed flag check at start of both `Dispose` methods
- Proper `GC.SuppressFinalize` calls in both dispose patterns

This enables proper async cleanup for classes with async operations, avoiding blocking `GetAwaiter().GetResult()` calls during disposal.

## Test plan

- [x] Build passes with no errors
- [x] All 39 unit tests pass
- [x] Verified IAsyncDisposable pattern follows Microsoft best practices

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)