### PR TITLE
Refactor: Extract DI registration and endpoints from Program.cs (#70)

### DIFF
--- a/src/SpeechToText.Service/EndpointExtensions.cs
+++ b/src/SpeechToText.Service/EndpointExtensions.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+using Olbrasoft.SpeechToText.Service.Hubs;
+using Olbrasoft.SpeechToText.Service.Services;
+
+namespace Olbrasoft.SpeechToText.Service;
+
+/// <summary>
+/// Extension methods for mapping SpeechToText API endpoints.
+/// </summary>
+public static class EndpointExtensions
+{
+    /// <summary>
+    /// Maps all SpeechToText API endpoints and SignalR hubs.
+    /// </summary>
+    public static WebApplication MapSpeechToTextEndpoints(this WebApplication app)
+    {
+        // Map SignalR hub
+        app.MapHub<PttHub>("/hubs/ptt");
+
+        // Health check endpoint
+        app.MapGet("/", () => Results.Ok(new { service = "Olbrasoft.SpeechToText", status = "running" }));
+
+        // Repeat last transcription endpoint - copies last text to clipboard
+        app.MapPost("/api/ptt/repeat", RepeatTranscriptionHandler);
+
+        return app;
+    }
+
+    private static async Task<IResult> RepeatTranscriptionHandler(
+        ITranscriptionHistory history,
+        ILogger<Program> logger)
+    {
+        var lastText = history.LastText;
+
+        if (string.IsNullOrEmpty(lastText))
+        {
+            logger.LogWarning("Repeat requested but no transcription history available");
+            return Results.NotFound(new { success = false, message = "No transcription history available" });
+        }
+
+        try
+        {
+            // Copy to clipboard using wl-copy
+            var wlCopyProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "wl-copy",
+                    RedirectStandardInput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            wlCopyProcess.Start();
+            await wlCopyProcess.StandardInput.WriteAsync(lastText);
+            wlCopyProcess.StandardInput.Close();
+            await wlCopyProcess.WaitForExitAsync();
+
+            if (wlCopyProcess.ExitCode != 0)
+            {
+                var error = await wlCopyProcess.StandardError.ReadToEndAsync();
+                logger.LogError("wl-copy failed with exit code {ExitCode}: {Error}", wlCopyProcess.ExitCode, error);
+                return Results.StatusCode(500);
+            }
+
+            logger.LogInformation("Repeat: copied last transcription to clipboard ({Length} chars)", lastText.Length);
+            return Results.Ok(new { success = true, text = lastText, copiedToClipboard = true });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to copy text to clipboard");
+            return Results.StatusCode(500);
+        }
+    }
+}

--- a/src/SpeechToText.Service/ServiceCollectionExtensions.cs
+++ b/src/SpeechToText.Service/ServiceCollectionExtensions.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Olbrasoft.SpeechToText.Audio;
+using Olbrasoft.SpeechToText.Core.Interfaces;
+using Olbrasoft.SpeechToText.Service.Services;
+using Olbrasoft.SpeechToText.Speech;
+using Olbrasoft.SpeechToText.TextInput;
+
+// Disambiguate types that exist in multiple namespaces
+using PttManualMuteService = Olbrasoft.SpeechToText.Service.Services.ManualMuteService;
+using PttEvdevKeyboardMonitor = Olbrasoft.SpeechToText.EvdevKeyboardMonitor;
+
+namespace Olbrasoft.SpeechToText.Service;
+
+/// <summary>
+/// Extension methods for registering SpeechToText services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds all SpeechToText services to the service collection.
+    /// </summary>
+    public static IServiceCollection AddSpeechToTextServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Get configuration values
+        var keyboardDevice = configuration.GetValue<string?>("PushToTalkDictation:KeyboardDevice");
+        var ggmlModelPath = configuration.GetValue<string>("PushToTalkDictation:GgmlModelPath")
+            ?? Path.Combine(AppContext.BaseDirectory, "models", "ggml-medium.bin");
+        var whisperLanguage = configuration.GetValue<string>("PushToTalkDictation:WhisperLanguage") ?? "cs";
+        var bluetoothTripleClickCommand = configuration.GetValue<string?>("BluetoothMouse:TripleClickCommand");
+
+        // SignalR
+        services.AddSignalR();
+
+        // CORS (for web clients)
+        services.AddCors(options =>
+        {
+            options.AddDefaultPolicy(policy =>
+            {
+                policy.AllowAnyOrigin()
+                      .AllowAnyHeader()
+                      .AllowAnyMethod();
+            });
+        });
+
+        // PTT Notifier service
+        services.AddSingleton<IPttNotifier, PttNotifier>();
+
+        // Transcription history service (single-level history for repeat functionality)
+        services.AddSingleton<ITranscriptionHistory, TranscriptionHistory>();
+
+        // Manual mute service (ScrollLock) - register as concrete type for injection
+        // Also register interface for backwards compatibility
+        services.AddSingleton<PttManualMuteService>();
+        services.AddSingleton<Olbrasoft.SpeechToText.Services.IManualMuteService>(sp =>
+            sp.GetRequiredService<PttManualMuteService>());
+
+        // Register services
+        services.AddSingleton<IKeyboardMonitor>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<PttEvdevKeyboardMonitor>>();
+            return new PttEvdevKeyboardMonitor(logger, keyboardDevice);
+        });
+
+        // Key simulator (ISP: separated from keyboard monitoring)
+        services.AddSingleton<IKeySimulator, UinputKeySimulator>();
+
+        services.AddSingleton<IAudioRecorder>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<AlsaAudioRecorder>>();
+            return new AlsaAudioRecorder(logger);
+        });
+
+        services.AddSingleton<ISpeechTranscriber>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<WhisperNetTranscriber>>();
+            return new WhisperNetTranscriber(logger, ggmlModelPath, whisperLanguage);
+        });
+
+        // Environment provider for display server detection
+        services.AddSingleton<IEnvironmentProvider, SystemEnvironmentProvider>();
+
+        // Text typer factory (injectable, testable)
+        services.AddSingleton<ITextTyperFactory, TextTyperFactory>();
+
+        // Auto-detect display server (X11/Wayland) and use appropriate text typer
+        services.AddSingleton<ITextTyper>(sp =>
+        {
+            var factory = sp.GetRequiredService<ITextTyperFactory>();
+            var logger = sp.GetRequiredService<ILogger<Program>>();
+            logger.LogInformation("Detected display server: {DisplayServer}", factory.GetDisplayServerName());
+            return factory.Create();
+        });
+
+        // Typing sound player for transcription feedback
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<TypingSoundPlayer>>();
+            var soundsDirectory = Path.Combine(AppContext.BaseDirectory, "sounds");
+            return TypingSoundPlayer.CreateFromDirectory(logger, soundsDirectory);
+        });
+
+        // Transcription tray service (not from DI - needs special lifecycle with GTK)
+        services.AddSingleton<Tray.TranscriptionTrayService>();
+
+        // Hallucination filter for Whisper transcriptions
+        services.Configure<HallucinationFilterOptions>(
+            configuration.GetSection(HallucinationFilterOptions.SectionName));
+        services.AddSingleton<IHallucinationFilter, WhisperHallucinationFilter>();
+
+        // Speech lock service (file-based lock to prevent TTS during recording)
+        services.AddSingleton<ISpeechLockService, SpeechLockService>();
+
+        // TTS control service (HTTP client for TTS and VirtualAssistant APIs)
+        services.AddHttpClient<ITtsControlService, TtsControlService>();
+
+        // HTTP client for DictationWorker
+        services.AddHttpClient<DictationWorker>();
+
+        // Bluetooth mouse monitor (remote push-to-talk trigger)
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<BluetoothMouseMonitor>>();
+            var keyboardMonitor = sp.GetRequiredService<IKeyboardMonitor>();
+            var keySimulator = sp.GetRequiredService<IKeySimulator>();
+            return new BluetoothMouseMonitor(logger, keyboardMonitor, keySimulator, "BluetoothMouse3600", bluetoothTripleClickCommand);
+        });
+
+        // USB Optical Mouse monitor (secondary push-to-talk trigger)
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<UsbMouseMonitor>>();
+            var keyboardMonitor = sp.GetRequiredService<IKeyboardMonitor>();
+            var keySimulator = sp.GetRequiredService<IKeySimulator>();
+            return new UsbMouseMonitor(logger, keyboardMonitor, keySimulator);
+        });
+
+        // Register worker
+        services.AddHostedService<DictationWorker>();
+
+        return services;
+    }
+}

--- a/src/SpeechToText.Service/SingleInstanceLock.cs
+++ b/src/SpeechToText.Service/SingleInstanceLock.cs
@@ -1,0 +1,84 @@
+using System.Text;
+
+namespace Olbrasoft.SpeechToText.Service;
+
+/// <summary>
+/// Ensures only one instance of the service is running.
+/// </summary>
+public sealed class SingleInstanceLock : IDisposable
+{
+    private readonly string _lockFilePath;
+    private FileStream? _lockFile;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new single instance lock.
+    /// </summary>
+    /// <param name="lockFilePath">Path to the lock file.</param>
+    private SingleInstanceLock(string lockFilePath)
+    {
+        _lockFilePath = lockFilePath;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the lock was acquired.
+    /// </summary>
+    public bool IsAcquired => _lockFile != null;
+
+    /// <summary>
+    /// Tries to acquire a single instance lock.
+    /// </summary>
+    /// <param name="lockFilePath">Path to the lock file.</param>
+    /// <returns>A lock instance (check IsAcquired to see if lock was obtained).</returns>
+    public static SingleInstanceLock TryAcquire(string lockFilePath = "/tmp/push-to-talk-dictation.lock")
+    {
+        var lockInstance = new SingleInstanceLock(lockFilePath);
+
+        try
+        {
+            lockInstance._lockFile = new FileStream(
+                lockFilePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None);
+
+            // Write PID to lock file for debugging
+            var pidBytes = Encoding.UTF8.GetBytes(Environment.ProcessId.ToString());
+            lockInstance._lockFile.Write(pidBytes, 0, pidBytes.Length);
+            lockInstance._lockFile.Flush();
+        }
+        catch (IOException)
+        {
+            // Lock file is held by another process
+            lockInstance._lockFile = null;
+        }
+
+        return lockInstance;
+    }
+
+    /// <summary>
+    /// Releases the lock and deletes the lock file.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        try
+        {
+            _lockFile?.Dispose();
+            _lockFile = null;
+
+            if (File.Exists(_lockFilePath))
+            {
+                File.Delete(_lockFilePath);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Created `ServiceCollectionExtensions.cs` for all DI registrations (~100 lines)
- Created `EndpointExtensions.cs` for API endpoint mapping (~70 lines)
- Created `SingleInstanceLock.cs` (reusable pattern from App project)
- Simplified `Program.cs` from 339 to 121 lines

## Changes

### New Files
| File | Purpose | Lines |
|------|---------|-------|
| `ServiceCollectionExtensions.cs` | All DI service registrations | ~128 |
| `EndpointExtensions.cs` | SignalR hub and API endpoints | ~72 |
| `SingleInstanceLock.cs` | Ensures single instance running | ~84 |

### Simplified Program.cs
Now only contains:
- Configuration loading
- Single instance check
- Service/app building using extension methods
- GTK tray initialization and main loop
- Shutdown handling

## Benefits
- **Readability** - Program.cs is now ~121 lines (was 339)
- **Testability** - Extension methods can be unit tested
- **Reusability** - Extensions can be reused in other contexts
- **Consistency** - Matches App project structure

## Test plan
- [x] All 266 tests pass
- [x] Build succeeds with no errors

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)